### PR TITLE
Bump minimum Python version and several development dependencies.

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -11,7 +11,9 @@ jobs:
   build-documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: 3.11
       - uses: snok/install-poetry@v1
       - run: |
           poetry install --with docs

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,8 +7,10 @@ jobs:
   upload-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - uses: snok/install-poetry@v1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11""]
+        python-version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - uses: snok/install-poetry@v1
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - uses: snok/install-poetry@v1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -14,7 +14,9 @@ jobs:
         shell: bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -28,7 +30,7 @@ jobs:
           source $VENV
           black . --check
           isort . --check
-          ruff mfglib tests
+          ruff check mfglib tests
   test:
     strategy:
       fail-fast: false
@@ -43,7 +45,9 @@ jobs:
       group: ${{ matrix.os }}-${{ matrix.python-version }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11""]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,10 @@ jobs:
         shell: bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - uses: snok/install-poetry@v1

--- a/docs/source/citations.rst
+++ b/docs/source/citations.rst
@@ -12,6 +12,5 @@ the following BibTeX entry:
         journal = {arXiv preprint arXiv:2304.08630},
         year    = {2023}
     }
+
 If you find MFGLib to be helpful and would like to send virtual kudos, please consider leaving a star on the `GitHub repository <https://github.com/radar-research-lab/MFGLib>`_.
-
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ A Library for Mean-Field Games
 Installation
 ------------
 
-MFGLib provides pre-built wheels for Python 3.8+ and can be installed via ``pip`` on
+MFGLib provides pre-built wheels for Python 3.9+ and can be installed via ``pip`` on
 all major platforms:
 
 .. code-block::

--- a/mfglib/alg/q_fn.py
+++ b/mfglib/alg/q_fn.py
@@ -91,7 +91,7 @@ class QFn:
         def future_rewards(t: int, q_values: torch.Tensor) -> torch.Tensor:
             l_s = len(self.env.S)
             max_q = q_values[t + 1].flatten(start_dim=l_s).max(dim=-1)[0].flatten()
-            return cast(torch.Tensor, self._transition_probabilities(t) @ max_q)
+            return self._transition_probabilities(t) @ max_q
 
         return self._compute_q_values(future_rewards)
 

--- a/mfglib/env/environment.py
+++ b/mfglib/env/environment.py
@@ -10,13 +10,11 @@ import torch
 # `__call__`. In particular, this allows a user to pass either a function or a class
 # for the reward and transition functions.
 class RewardFn(Protocol):
-    def __call__(self, env: Environment, t: int, L_t: torch.Tensor) -> torch.Tensor:
-        ...
+    def __call__(self, env: Environment, t: int, L_t: torch.Tensor) -> torch.Tensor: ...
 
 
 class TransitionFn(Protocol):
-    def __call__(self, env: Environment, t: int, L_t: torch.Tensor) -> torch.Tensor:
-        ...
+    def __call__(self, env: Environment, t: int, L_t: torch.Tensor) -> torch.Tensor: ...
 
 
 class Environment:

--- a/mfglib/env/examples/linear_quadratic.py
+++ b/mfglib/env/examples/linear_quadratic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from typing import cast
 
 import torch
 
@@ -38,7 +39,7 @@ class TransitionFn:
                         + (self.k * (m_t - s + self.el) + a - self.m) * self.delta
                         + self.sigma * epsilon * math.sqrt(self.delta)
                     )
-                    s_next = torch.round(s_next_tensor).int().item()
+                    s_next = cast(int, torch.round(s_next_tensor).int().item())
                     s_next = min(max(-self.el, s_next), self.el)
                     p_t[s_next + self.el, s, a] += epsilon_pr
 

--- a/mfglib/metrics.py
+++ b/mfglib/metrics.py
@@ -12,15 +12,13 @@ __all__ = ["exploitability_score"]
 
 
 @overload
-def exploitability_score(env_instance: Environment, pi: torch.Tensor) -> float:
-    ...
+def exploitability_score(env_instance: Environment, pi: torch.Tensor) -> float: ...
 
 
 @overload
 def exploitability_score(
     env_instance: Environment, pi: list[torch.Tensor]
-) -> list[float]:
-    ...
+) -> list[float]: ...
 
 
 def exploitability_score(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,13 @@ license = "MIT"
 documentation = "https://mfglib.readthedocs.io/en/latest/"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 torch = "^2.0.0"
 optuna = "^3.1.0"
 
 [tool.poetry.group.dev.dependencies]
-isort = "5.12.0"
-black = "23.3.0"
+isort = "5.13.2"
+black = "24.10.0"
 mypy = "1.13.0"
 ruff = "0.0.261"
 pytest = "7.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ optuna = "^3.1.0"
 [tool.poetry.group.dev.dependencies]
 isort = "5.12.0"
 black = "23.3.0"
-mypy = "1.2.0"
+mypy = "1.13.0"
 ruff = "0.0.261"
 pytest = "7.3.0"
 coveralls = "3.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,12 @@ coveralls = "3.3.1"
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-sphinx = "6.1.3"
+sphinx = "7.4.7"
 sphinx-autobuild = "2021.3.14"
 sphinxcontrib-bibtex = "2.5.0"
 setuptools = "*"  # <-- required for sphinxcontrib-bibtex
 matplotlib = "3.7.1"
-jupyter_sphinx = "0.4.0"
+jupyter_sphinx = "0.5.3"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,14 @@ documentation = "https://mfglib.readthedocs.io/en/latest/"
 [tool.poetry.dependencies]
 python = "^3.9"
 torch = "^2.0.0"
+numpy = "~1"
 optuna = "^3.1.0"
 
 [tool.poetry.group.dev.dependencies]
 isort = "5.13.2"
 black = "24.10.0"
 mypy = "1.13.0"
-ruff = "0.0.261"
+ruff = "0.7.4"
 pytest = "8.3.3"
 coveralls = "3.3.1"
 
@@ -40,13 +41,13 @@ jupyter_sphinx = "0.4.0"
 [tool.isort]
 profile = "black"
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["D"]
 ignore = ["D100", "D101", "D102", "D104"]
 # We don't enforce docstrings in test functions
 per-file-ignores = {"tests/test_*.py" = ["D103"]}
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ isort = "5.13.2"
 black = "24.10.0"
 mypy = "1.13.0"
 ruff = "0.0.261"
-pytest = "7.3.0"
+pytest = "8.3.3"
 coveralls = "3.3.1"
 
 [tool.poetry.group.docs]


### PR DESCRIPTION
Python 3.8 recently reached EoL so it is an appropriate time to raise our minimum supported version.