### PR TITLE
Fix bugs in Beach Bar environment

### DIFF
--- a/mfglib/env/examples/beach_bar.py
+++ b/mfglib/env/examples/beach_bar.py
@@ -21,8 +21,13 @@ class TransitionFn:
 
 class RewardFn:
     def __init__(self, n: int, bar_loc: int, log_eps: float) -> None:
-        self.c1 = torch.abs(
-            torch.arange(0, n).repeat(3, 1).T - bar_loc * torch.ones(n, 3)
+        self.c1 = (
+            -torch.min(
+                torch.arange(n).roll(bar_loc),
+                torch.arange(n).flip(dims=[0]).roll(bar_loc + 1),
+            )
+            .unsqueeze(dim=1)
+            .broadcast_to(size=[n, 3])
         )
         self.c2 = -torch.tensor([1, 0, 1]).repeat(n, 1) / n
         self.log_eps = log_eps


### PR DESCRIPTION
Closes #40.

The distance penalty is now computed as 

```python
(
    -torch.min(
        torch.arange(n).roll(bar_loc),
        torch.arange(n).flip(dims=[0]).roll(bar_loc + 1),
    )
    .unsqueeze(dim=1)
    .broadcast_to(size=[n, 3])
)
```

which for `n = 6, bar_loc = 3` gives

```python
tensor([[-3, -3, -3],
        [-2, -2, -2],
        [-1, -1, -1],
        [ 0,  0,  0],
        [-1, -1, -1],
        [-2, -2, -2]])
```

and for `n = 6, bar_loc = 5` gives 

```python
tensor([[-1, -1, -1],
        [-2, -2, -2],
        [-3, -3, -3],
        [-2, -2, -2],
        [-1, -1, -1],
        [ 0,  0,  0]])
```

The result is two-dimensional, with element $(i, j)$ corresponding with the penalty of being in state $i$ and taking action $j$.