### PR TITLE
Introduce towncrier for changelog management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/radar-research-lab/MFGLib/tree/main/changelog.d/>.
+
+<!-- towncrier release notes start -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,23 @@ To ensure that the documentation build successfully (with no errors), run
 ```shell
 sphinx-build -EW docs/source docs/build
 ```
+
+## CHANGELOG
+
+Any pull request that makes a significant change to `MFGLib` should include a new entry in `MFGLib/changelog.d/`.
+To generate a new entry, run the command
+
+```shell
+$ towncrier create -c "{description of the change}" {issue}.{type}.md
+```
+
+If your change corresponds with a GitHub issue, replace `{issue}` with the issue number. If there
+is no corresponding GitHub issue, replace `{issue}` with a unique identifier starting with `+`. The 
+`{type}` placeholder should be replaced by one of
+
+- `security`
+- `removed`
+- `deprecated`
+- `added`
+- `changed`
+- `fixed`

--- a/changelog.d/+MFOMI.added.md
+++ b/changelog.d/+MFOMI.added.md
@@ -1,0 +1,1 @@
+Introduce Mean-Field Occupation Measure Inclusion algorithm

--- a/changelog.d/+save_and_load.added.md
+++ b/changelog.d/+save_and_load.added.md
@@ -1,0 +1,1 @@
+Add save and load methods to Algorithm

--- a/changelog.d/40.fixed.md
+++ b/changelog.d/40.fixed.md
@@ -1,0 +1,1 @@
+Fix bugs in Beach Bar environment

--- a/changelog.d/45.added.md
+++ b/changelog.d/45.added.md
@@ -1,0 +1,1 @@
+Introduce `CHANGELOG.md` to better document version-to-version changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ mypy = "1.15.0"
 ruff = "0.9.6"
 pytest = "8.3.4"
 coverage = "7.6.12"
+towncrier = "24.8.0"
 
 [tool.poetry.group.docs]
 optional = true
@@ -63,6 +64,45 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = "error"
+
+[tool.towncrier]
+package = "mfglib"
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+title_format = "## [{version}](https://github.com/radar-research-lab/MFGLib/tree/{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/radar-research-lab/MFGLib/issues/{issue})"
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
@junziz I've described the usage in `CONTRIBUTING.md`, but at a high-level this PR allows us to store a record of unreleased changes in a directory `changelog.d`. When we want to publish a new version,`towncrier` collect the "news fragments" and prepends them to `CHANGELOG.md`.