### PR TITLE
Improve printouts

### DIFF
--- a/changelog.d/47.changed.md
+++ b/changelog.d/47.changed.md
@@ -1,0 +1,1 @@
+Improved verbose printouts

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "MFGLib"
-copyright = "2023, RADAR Reasearch Lab"
+copyright = "2025, RADAR Research Lab"
 author = "RADAR Research Lab"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,11 +101,11 @@ The computed exploitability score is decreased significantly implying that the l
 approximation of an NE solution for the **Beach Bar** environment.
 
 
-You can monitor the progression of an algorithm by plotting the exploitability scores vs. the number of iterations
-as shown below.
+You can monitor the progression of an algorithm by setting its `verbose`` parameter to a positive integer.
 
-.. plot:: plots.py plot_beach_bar_exploitability
-   :show-source-link: False
+.. jupyter-execute::
+
+   _ = online_mirror_descent.solve(beach_bar, verbose=1)
 
 More on Exploitability
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/mfglib/alg/abc.py
+++ b/mfglib/alg/abc.py
@@ -42,7 +42,7 @@ class Algorithm(abc.ABC):
         max_iter: int = DEFAULT_MAX_ITER,
         atol: float | None = DEFAULT_ATOL,
         rtol: float | None = DEFAULT_RTOL,
-        verbose: bool = False,
+        verbose: int = 0,
     ) -> tuple[list[torch.Tensor], list[float], list[float]]:
         """Run the algorithm and solve for a Nash-Equilibrium policy."""
         raise NotImplementedError

--- a/mfglib/alg/fictitious_play.py
+++ b/mfglib/alg/fictitious_play.py
@@ -101,29 +101,22 @@ class FictitiousPlay(Algorithm):
         pi = _ensure_free_tensor(pi, env_instance)
 
         solutions = [pi]
-        argmin = 0
         scores = [exploitability_score(env_instance, pi)]
         runtimes = [0.0]
 
-        printer = Printer(verbose=verbose)
-        printer.print_info_panels(
+        printer = Printer.setup(
+            verbose=verbose,
             env_instance=env_instance,
-            cls="FictitiousPlay",
+            solver="FictitiousPlay",
             parameters={"alpha": self.alpha},
             atol=atol,
             rtol=rtol,
             max_iter=max_iter,
-        )
-        printer.add_table_row(
-            n=0,
-            expl_n=scores[0],
             expl_0=scores[0],
-            argmin=argmin,
-            runtime_n=runtimes[0],
         )
 
         if _trigger_early_stopping(scores[0], scores[0], atol, rtol):
-            printer.alert_stopped_early()
+            printer.alert_early_stopping()
             return solutions, scores, runtimes
 
         t = time.time()
@@ -158,24 +151,15 @@ class FictitiousPlay(Algorithm):
 
             solutions.append(pi.clone().detach())
             scores.append(exploitability_score(env_instance, pi))
-            if scores[n] < scores[argmin]:
-                argmin = n
             runtimes.append(time.time() - t)
 
-            printer.add_table_row(
-                n=n,
-                expl_n=scores[n],
-                expl_0=scores[0],
-                argmin=argmin,
-                runtime_n=runtimes[n],
-            )
+            printer.notify_of_solution(n=n, expl_n=scores[n], runtime_n=runtimes[n])
 
             if _trigger_early_stopping(scores[0], scores[n], atol, rtol):
-                printer.alert_stopped_early()
+                printer.alert_early_stopping()
                 return solutions, scores, runtimes
 
         printer.alert_iterations_exhausted()
-
         return solutions, scores, runtimes
 
     @classmethod

--- a/mfglib/alg/mf_omo.py
+++ b/mfglib/alg/mf_omo.py
@@ -350,14 +350,13 @@ class MFOMO(Algorithm):
             )
 
         solutions = [pi]
-        argmin = 0
         scores = [exploitability_score(env_instance, pi)]
         runtimes = [0.0]
 
-        printer = Printer(verbose=verbose)
-        printer.print_info_panels(
+        printer = Printer.setup(
+            verbose=verbose,
             env_instance=env_instance,
-            cls="MF-OMO",
+            solver="MF-OMO",
             parameters={
                 "loss": self.loss,
                 "c1": self.c1,
@@ -373,17 +372,11 @@ class MFOMO(Algorithm):
             atol=atol,
             rtol=rtol,
             max_iter=max_iter,
-        )
-        printer.add_table_row(
-            n=0,
-            expl_n=scores[0],
             expl_0=scores[0],
-            argmin=argmin,
-            runtime_n=runtimes[0],
         )
 
         if _trigger_early_stopping(scores[0], scores[0], atol, rtol):
-            printer.alert_stopped_early()
+            printer.alert_early_stopping()
             return solutions, scores, runtimes
 
         t = time.time()
@@ -445,24 +438,15 @@ class MFOMO(Algorithm):
 
             solutions.append(pi.clone().detach())
             scores.append(exploitability_score(env_instance, pi))
-            if scores[n] < scores[argmin]:
-                argmin = n
             runtimes.append(time.time() - t)
 
-            printer.add_table_row(
-                n=n,
-                expl_n=scores[n],
-                expl_0=scores[0],
-                argmin=argmin,
-                runtime_n=runtimes[n],
-            )
+            printer.notify_of_solution(n=n, expl_n=scores[n], runtime_n=runtimes[n])
 
             if _trigger_early_stopping(scores[0], scores[n], atol, rtol):
-                printer.alert_stopped_early()
+                printer.alert_early_stopping()
                 return solutions, scores, runtimes
 
         printer.alert_iterations_exhausted()
-
         return solutions, scores, runtimes
 
     @classmethod

--- a/mfglib/alg/occupation_measure_inclusion.py
+++ b/mfglib/alg/occupation_measure_inclusion.py
@@ -12,10 +12,8 @@ from scipy import sparse
 from mfglib.alg.abc import DEFAULT_ATOL, DEFAULT_MAX_ITER, DEFAULT_RTOL, Algorithm
 from mfglib.alg.mf_omo_params import mf_omo_params
 from mfglib.alg.utils import (
+    Printer,
     _ensure_free_tensor,
-    _print_fancy_header,
-    _print_fancy_table_row,
-    _print_solve_complete,
     _trigger_early_stopping,
     extract_policy_from_mean_field,
 )
@@ -92,7 +90,7 @@ class OccupationMeasureInclusion(Algorithm):
         max_iter: int = DEFAULT_MAX_ITER,
         atol: float | None = DEFAULT_ATOL,
         rtol: float | None = DEFAULT_RTOL,
-        verbose: bool = False,
+        verbose: int = 0,
     ) -> tuple[list[torch.Tensor], list[float], list[float]]:
         """Run the algorithm and solve for a Nash-Equilibrium policy.
 
@@ -119,25 +117,25 @@ class OccupationMeasureInclusion(Algorithm):
         scores = [exploitability_score(env_instance, pi)]
         runtimes = [0.0]
 
-        if verbose:
-            _print_fancy_header(
-                alg_instance=self,
-                env_instance=env_instance,
-                max_iter=max_iter,
-                atol=atol,
-                rtol=rtol,
-            )
-            _print_fancy_table_row(
-                n=0,
-                score_n=scores[0],
-                score_0=scores[0],
-                argmin=argmin,
-                runtime_n=runtimes[0],
-            )
+        printer = Printer(verbose=verbose)
+        printer.print_info_panels(
+            env_instance=env_instance,
+            cls="MF-OMI-FBS",
+            parameters={"alpha": self.alpha, "eta": self.eta},
+            atol=atol,
+            rtol=rtol,
+            max_iter=max_iter,
+        )
+        printer.add_table_row(
+            n=0,
+            expl_n=scores[0],
+            expl_0=scores[0],
+            argmin=argmin,
+            runtime_n=runtimes[0],
+        )
 
         if _trigger_early_stopping(scores[0], scores[0], atol, rtol):
-            if verbose:
-                _print_solve_complete(seconds_elapsed=runtimes[0])
+            printer.alert_stopped_early()
             return solutions, scores, runtimes
 
         # initialize d = L^pi
@@ -162,22 +160,19 @@ class OccupationMeasureInclusion(Algorithm):
                 argmin = n
             runtimes.append(time.time() - t)
 
-            if verbose:
-                _print_fancy_table_row(
-                    n=n,
-                    score_n=scores[n],
-                    score_0=scores[0],
-                    argmin=argmin,
-                    runtime_n=runtimes[n],
-                )
+            printer.add_table_row(
+                n=n,
+                expl_n=scores[n],
+                expl_0=scores[0],
+                argmin=argmin,
+                runtime_n=runtimes[n],
+            )
 
             if _trigger_early_stopping(scores[0], scores[n], atol, rtol):
-                if verbose:
-                    _print_solve_complete(seconds_elapsed=runtimes[n])
+                printer.alert_stopped_early()
                 return solutions, scores, runtimes
 
-        if verbose:
-            _print_solve_complete(seconds_elapsed=time.time() - t)
+        printer.alert_iterations_exhausted()
 
         return solutions, scores, runtimes
 

--- a/mfglib/alg/online_mirror_descent.py
+++ b/mfglib/alg/online_mirror_descent.py
@@ -8,13 +8,7 @@ import torch
 
 from mfglib.alg.abc import DEFAULT_ATOL, DEFAULT_MAX_ITER, DEFAULT_RTOL, Algorithm
 from mfglib.alg.q_fn import QFn
-from mfglib.alg.utils import (
-    _ensure_free_tensor,
-    _print_fancy_header,
-    _print_fancy_table_row,
-    _print_solve_complete,
-    _trigger_early_stopping,
-)
+from mfglib.alg.utils import Printer, _ensure_free_tensor, _trigger_early_stopping
 from mfglib.env import Environment
 from mfglib.mean_field import mean_field
 from mfglib.scoring import exploitability_score
@@ -53,7 +47,7 @@ class OnlineMirrorDescent(Algorithm):
         max_iter: int = DEFAULT_MAX_ITER,
         atol: float | None = DEFAULT_ATOL,
         rtol: float | None = DEFAULT_RTOL,
-        verbose: bool = False,
+        verbose: int = 0,
     ) -> tuple[list[torch.Tensor], list[float], list[float]]:
         """Run the algorithm and solve for a Nash-Equilibrium policy.
 
@@ -92,25 +86,25 @@ class OnlineMirrorDescent(Algorithm):
         scores = [exploitability_score(env_instance, pi)]
         runtimes = [0.0]
 
-        if verbose:
-            _print_fancy_header(
-                alg_instance=self,
-                env_instance=env_instance,
-                max_iter=max_iter,
-                atol=atol,
-                rtol=rtol,
-            )
-            _print_fancy_table_row(
-                n=0,
-                score_n=scores[0],
-                score_0=scores[0],
-                argmin=argmin,
-                runtime_n=runtimes[0],
-            )
+        printer = Printer(verbose=verbose)
+        printer.print_info_panels(
+            env_instance=env_instance,
+            cls="OnlineMirrorDescent",
+            parameters={"alpha": self.alpha},
+            atol=atol,
+            rtol=rtol,
+            max_iter=max_iter,
+        )
+        printer.add_table_row(
+            n=0,
+            expl_n=scores[0],
+            expl_0=scores[0],
+            argmin=argmin,
+            runtime_n=runtimes[0],
+        )
 
         if _trigger_early_stopping(scores[0], scores[0], atol, rtol):
-            if verbose:
-                _print_solve_complete(seconds_elapsed=runtimes[0])
+            printer.alert_stopped_early()
             return solutions, scores, runtimes
 
         t = time.time()
@@ -134,22 +128,19 @@ class OnlineMirrorDescent(Algorithm):
                 argmin = n
             runtimes.append(time.time() - t)
 
-            if verbose:
-                _print_fancy_table_row(
-                    n=n,
-                    score_n=scores[n],
-                    score_0=scores[0],
-                    argmin=argmin,
-                    runtime_n=runtimes[n],
-                )
+            printer.add_table_row(
+                n=n,
+                expl_n=scores[n],
+                expl_0=scores[0],
+                argmin=argmin,
+                runtime_n=runtimes[n],
+            )
 
             if _trigger_early_stopping(scores[0], scores[n], atol, rtol):
-                if verbose:
-                    _print_solve_complete(seconds_elapsed=runtimes[n])
+                printer.alert_stopped_early()
                 return solutions, scores, runtimes
 
-        if verbose:
-            _print_solve_complete(seconds_elapsed=time.time() - t)
+        printer.alert_iterations_exhausted()
 
         return solutions, scores, runtimes
 

--- a/mfglib/alg/prior_descent.py
+++ b/mfglib/alg/prior_descent.py
@@ -8,13 +8,7 @@ import torch
 
 from mfglib.alg.abc import DEFAULT_ATOL, DEFAULT_MAX_ITER, DEFAULT_RTOL, Algorithm
 from mfglib.alg.q_fn import QFn
-from mfglib.alg.utils import (
-    _ensure_free_tensor,
-    _print_fancy_header,
-    _print_fancy_table_row,
-    _print_solve_complete,
-    _trigger_early_stopping,
-)
+from mfglib.alg.utils import Printer, _ensure_free_tensor, _trigger_early_stopping
 from mfglib.env import Environment
 from mfglib.mean_field import mean_field
 from mfglib.scoring import exploitability_score
@@ -69,7 +63,7 @@ class PriorDescent(Algorithm):
         max_iter: int = DEFAULT_MAX_ITER,
         atol: float | None = DEFAULT_ATOL,
         rtol: float | None = DEFAULT_RTOL,
-        verbose: bool = False,
+        verbose: int = 0,
     ) -> tuple[list[torch.Tensor], list[float], list[float]]:
         """Run the algorithm and solve for a Nash-Equilibrium policy.
 
@@ -105,25 +99,25 @@ class PriorDescent(Algorithm):
         scores = [exploitability_score(env_instance, pi)]
         runtimes = [0.0]
 
-        if verbose:
-            _print_fancy_header(
-                alg_instance=self,
-                env_instance=env_instance,
-                max_iter=max_iter,
-                atol=atol,
-                rtol=rtol,
-            )
-            _print_fancy_table_row(
-                n=0,
-                score_n=scores[0],
-                score_0=scores[0],
-                argmin=argmin,
-                runtime_n=runtimes[0],
-            )
+        printer = Printer(verbose=verbose)
+        printer.print_info_panels(
+            env_instance=env_instance,
+            cls="PriorDescent",
+            parameters={"eta": self.eta, "n_inner": self.n_inner},
+            atol=atol,
+            rtol=rtol,
+            max_iter=max_iter,
+        )
+        printer.add_table_row(
+            n=0,
+            expl_n=scores[0],
+            expl_0=scores[0],
+            argmin=argmin,
+            runtime_n=runtimes[0],
+        )
 
         if _trigger_early_stopping(scores[0], scores[0], atol, rtol):
-            if verbose:
-                _print_solve_complete(seconds_elapsed=runtimes[0])
+            printer.alert_stopped_early()
             return solutions, scores, runtimes
 
         t = time.time()
@@ -155,22 +149,19 @@ class PriorDescent(Algorithm):
                 argmin = n
             runtimes.append(time.time() - t)
 
-            if verbose:
-                _print_fancy_table_row(
-                    n=n,
-                    score_n=scores[n],
-                    score_0=scores[0],
-                    argmin=argmin,
-                    runtime_n=runtimes[n],
-                )
+            printer.add_table_row(
+                n=n,
+                expl_n=scores[n],
+                expl_0=scores[0],
+                argmin=argmin,
+                runtime_n=runtimes[n],
+            )
 
             if _trigger_early_stopping(scores[0], scores[n], atol, rtol):
-                if verbose:
-                    _print_solve_complete(seconds_elapsed=runtimes[n])
+                printer.alert_stopped_early()
                 return solutions, scores, runtimes
 
-        if verbose:
-            _print_solve_complete(seconds_elapsed=time.time() - t)
+        printer.alert_iterations_exhausted()
 
         return solutions, scores, runtimes
 

--- a/mfglib/alg/prior_descent.py
+++ b/mfglib/alg/prior_descent.py
@@ -95,29 +95,22 @@ class PriorDescent(Algorithm):
         q = pi.clone()
 
         solutions = [pi]
-        argmin = 0
         scores = [exploitability_score(env_instance, pi)]
         runtimes = [0.0]
 
-        printer = Printer(verbose=verbose)
-        printer.print_info_panels(
+        printer = Printer.setup(
+            verbose=verbose,
             env_instance=env_instance,
-            cls="PriorDescent",
+            solver="PriorDescent",
             parameters={"eta": self.eta, "n_inner": self.n_inner},
             atol=atol,
             rtol=rtol,
             max_iter=max_iter,
-        )
-        printer.add_table_row(
-            n=0,
-            expl_n=scores[0],
             expl_0=scores[0],
-            argmin=argmin,
-            runtime_n=runtimes[0],
         )
 
         if _trigger_early_stopping(scores[0], scores[0], atol, rtol):
-            printer.alert_stopped_early()
+            printer.alert_early_stopping()
             return solutions, scores, runtimes
 
         t = time.time()
@@ -145,24 +138,15 @@ class PriorDescent(Algorithm):
 
             solutions.append(pi.clone().detach())
             scores.append(exploitability_score(env_instance, pi))
-            if scores[n] < scores[argmin]:
-                argmin = n
             runtimes.append(time.time() - t)
 
-            printer.add_table_row(
-                n=n,
-                expl_n=scores[n],
-                expl_0=scores[0],
-                argmin=argmin,
-                runtime_n=runtimes[n],
-            )
+            printer.notify_of_solution(n=n, expl_n=scores[n], runtime_n=runtimes[n])
 
             if _trigger_early_stopping(scores[0], scores[n], atol, rtol):
-                printer.alert_stopped_early()
+                printer.alert_early_stopping()
                 return solutions, scores, runtimes
 
         printer.alert_iterations_exhausted()
-
         return solutions, scores, runtimes
 
     @classmethod

--- a/mfglib/alg/utils.py
+++ b/mfglib/alg/utils.py
@@ -150,12 +150,14 @@ class Printer:
                 self.table = _new_table()
 
     def alert_early_stopping(self) -> None:
-        rich_print(self.table)
-        rich_print("Absolute or relative stopping criteria met.")
+        if self.verbose > 0:
+            rich_print(self.table)
+            rich_print("Absolute or relative stopping criteria met.")
 
     def alert_iterations_exhausted(self) -> None:
-        rich_print(self.table)
-        rich_print("Number of iterations exhausted.")
+        if self.verbose > 0:
+            rich_print(self.table)
+            rich_print("Number of iterations exhausted.")
 
 
 def _ensure_free_tensor(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ numpy = "^2"
 optuna = "^3.0"
 osqp = "^0"
 scipy = "^1"
+rich = "^14.0.0"
 
 [tool.poetry.group.dev.dependencies]
 isort = "6.0.0"


### PR DESCRIPTION
Closes #47.

This PR uses `rich` to produce nicer-looking printouts.

![Screenshot 2025-03-31 at 4 23 33 PM](https://github.com/user-attachments/assets/0e1aab07-57ae-409d-86d2-cb7ea99dd125)

There are a few notable changes. To start, the exploitability scores are now presented in scientific notation so we shouldn't have a loss of precision in the presentation. 

Secondly, rows now get printed in batches. This makes it easier to find the header. It also allows each batch to have a dynamically sized width, so we won't cut off numbers if they become too wide.

And lastly, I've changed the `verbosity` parameter from bool to int. If `verbosity > 0` then we print a row every `verbosity` iterations. This is useful if you are running for 100,000 iterations, and you don't want to be flooded with printouts. You can now request to only be informed every, say, 500 iterations.