### PR TITLE
Improved Printouts + Algorithm Refactor

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,10 @@ build:
   tools:
     python: "3.12"
   jobs:
-    install:
-      - curl -sSL https://install.python-poetry.org | python3 -
-      - /home/docs/.local/bin/poetry install --with docs --without dev
-    build:
-      html:
-        - /home/docs/.local/bin/poetry run sphinx-build -EW docs/source $READTHEDOCS_OUTPUT/html
+    post_install:
+      - pip install poetry
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "MFGLib"
-copyright = "2025, RADAR Research Lab"
+copyright = "2023, RADAR Research Lab"
 author = "RADAR Research Lab"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "MFGLib"
-copyright = "2023, RADAR Reasearch Lab"
+copyright = "2025, RADAR Research Lab"
 author = "RADAR Research Lab"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,7 +101,7 @@ The computed exploitability score is decreased significantly implying that the l
 approximation of an NE solution for the **Beach Bar** environment.
 
 
-You can monitor the progression of an algorithm by setting its `verbose`` parameter to a positive integer.
+You can monitor the progression of an algorithm by setting its ``verbose`` parameter to a positive integer.
 
 .. jupyter-execute::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,11 +101,11 @@ The computed exploitability score is decreased significantly implying that the l
 approximation of an NE solution for the **Beach Bar** environment.
 
 
-You can monitor the progression of an algorithm by plotting the exploitability scores vs. the number of iterations
-as shown below.
+You can monitor the progression of an algorithm by setting its `verbose`` parameter to a positive integer.
 
-.. plot:: plots.py plot_beach_bar_exploitability
-   :show-source-link: False
+.. jupyter-execute::
+
+   _ = online_mirror_descent.solve(beach_bar, verbose=1)
 
 More on Exploitability
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/plots.py
+++ b/docs/source/plots.py
@@ -97,7 +97,7 @@ def plot_mf_omo() -> None:
     for lr in lrs:
         opt = {"name": "Adam", "config": {"lr": lr}}
         _, expls, _ = MFOMO(optimizer=opt).solve(
-            env_instance=rock_paper_scissors,
+            env=rock_paper_scissors,
             max_iter=300,
             atol=None,
             rtol=None,

--- a/docs/source/plots.py
+++ b/docs/source/plots.py
@@ -26,7 +26,7 @@ def plot_fictitious_play() -> None:
     rock_paper_scissors = Environment.rock_paper_scissors()
     for alpha in [0.1, 0.5, 0.75, None]:
         _, expls, _ = FictitiousPlay(alpha=alpha).solve(
-            env_instance=rock_paper_scissors,
+            env=rock_paper_scissors,
             max_iter=300,
             atol=None,
             rtol=None,
@@ -47,7 +47,7 @@ def plot_online_mirror_descent() -> None:
     rock_paper_scissors = Environment.rock_paper_scissors()
     for alpha in [0.01, 0.1, 1.0, 10]:
         _, expls, _ = OnlineMirrorDescent(alpha=alpha).solve(
-            env_instance=rock_paper_scissors,
+            env=rock_paper_scissors,
             max_iter=300,
             atol=None,
             rtol=None,
@@ -72,7 +72,7 @@ def plot_prior_descent() -> None:
 
     for eta, n_inner in zip(eta_values, n_inner_values):
         _, expls, _ = PriorDescent(eta=eta, n_inner=n_inner).solve(
-            env_instance=rock_paper_scissors,
+            env=rock_paper_scissors,
             max_iter=300,
             atol=None,
             rtol=None,

--- a/mfglib/alg/abc.py
+++ b/mfglib/alg/abc.py
@@ -201,7 +201,6 @@ class Iterative(Algorithm, Generic[T]):
         pis = [pi_0]
         argmin = 0
         expls = [expl_score(env, pi_0)]
-        t_0 = time.time()
         rts = [0.0]
 
         state = self.init_state(env, pi_0)
@@ -227,6 +226,7 @@ class Iterative(Algorithm, Generic[T]):
             logger.flush_stopped()
             return pis, expls, rts
 
+        t_0 = time.time()
         for i in range(1, max_iter + 1):
             state = self.step_state(state)
             pis += [state.pi]

--- a/mfglib/alg/abc.py
+++ b/mfglib/alg/abc.py
@@ -60,11 +60,11 @@ class Algorithm(abc.ABC):
         self,
         env: Environment,
         *,
-        pi_0: Literal["uniform"] | torch.Tensor,
-        max_iter: int,
-        atol: float | None,
-        rtol: float | None,
-        verbose: int,
+        pi_0: Literal["uniform"] | torch.Tensor = ...,
+        max_iter: int = ...,
+        atol: float | None = ...,
+        rtol: float | None = ...,
+        verbose: int = ...,
     ) -> tuple[list[torch.Tensor], list[float], list[float]]:
         raise NotImplementedError
 
@@ -229,7 +229,7 @@ class Iterative(Algorithm, Generic[T]):
 
         for i in range(1, max_iter + 1):
             state = self.step_state(state)
-            pis += [state.pi_i]
+            pis += [state.pi]
             expls += [expl_score(env, pis[i])]
             rts += [time.time() - t_0]
             if expls[i] < expls[argmin]:

--- a/mfglib/alg/abc.py
+++ b/mfglib/alg/abc.py
@@ -7,6 +7,7 @@ import warnings
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Final,
     Generic,
     Iterable,
@@ -287,7 +288,7 @@ class Logger:
         self,
         env: Environment,
         cls: str,
-        parameters: dict[str, float | str | None],
+        parameters: dict[str, Any],
         atol: float | None,
         rtol: float | None,
         max_iter: int,
@@ -321,7 +322,7 @@ class Logger:
 
             alg_group = Group(
                 f"class = {cls}",
-                f"parameters = {pretty_repr(parameters)}",
+                f"parameters = {pretty_repr(parameters, max_width=self.INFO_PANEL_WIDTH)}",
                 f"atol = {atol}",
                 f"rtol = {rtol}",
                 f"max_iter = {max_iter}",
@@ -335,8 +336,6 @@ class Logger:
             )
 
             doc_group = Group(
-                f"- The verbosity level is set to {self.verbose}.",
-                "- Table output is printed 50 rows at a time.",
                 "- Ratio_n := Expl_n / Expl_0.",
                 "- Argmin_n := Argmin_{0≤i≤n} Expl_i.",
                 "- Elapsed_n measures time in seconds.",
@@ -368,9 +367,9 @@ class Logger:
     def flush_exhausted(self) -> None:
         if self.verbose:
             rich_print(self.table)
-            rich_print("Number of iterations exhausted.")
+            rich_print("Status: Number of iterations exhausted.")
 
     def flush_stopped(self) -> None:
         if self.verbose:
             rich_print(self.table)
-            rich_print("Absolute or relative stopping criteria met.")
+            rich_print("Status: Absolute or relative stopping criteria met.")

--- a/mfglib/alg/abc.py
+++ b/mfglib/alg/abc.py
@@ -173,7 +173,7 @@ class Algorithm(abc.ABC):
 
 
 class State(Protocol):
-    pi_i: torch.Tensor
+    pi: torch.Tensor
 
 
 T = TypeVar("T", bound=State)

--- a/mfglib/alg/abc.py
+++ b/mfglib/alg/abc.py
@@ -103,7 +103,7 @@ class Algorithm(abc.ABC, Generic[T]):
         for i in range(1, max_iter + 1):
             state = self.step_state(state)
             pis += [state.pi_i]
-            expls += expl_score(env, pis[i])
+            expls += [expl_score(env, pis[i])]
             rts += [time.time() - t_0]
             if expls[i] < expls[argmin]:
                 argmin = i
@@ -131,7 +131,7 @@ class Algorithm(abc.ABC, Generic[T]):
 
     @abc.abstractmethod
     @property
-    def parameters(self) -> dict[str, float | str]:
+    def parameters(self) -> dict[str, float | str | None]:
         raise NotImplementedError
 
     def save(self, path: Path | str) -> None:

--- a/mfglib/alg/abc.py
+++ b/mfglib/alg/abc.py
@@ -228,7 +228,7 @@ class Iterative(Algorithm, Generic[T]):
 
         t_0 = time.time()
         for i in range(1, max_iter + 1):
-            state = self.step_state(state)
+            state = self.step_next_state(state)
             pis += [state.pi]
             expls += [expl_score(env, pis[i])]
             rts += [time.time() - t_0]
@@ -253,11 +253,11 @@ class Iterative(Algorithm, Generic[T]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def step_state(self, state: T) -> T:
+    def step_next_state(self, state: T) -> T:
         raise NotImplementedError
 
-    @abc.abstractmethod
     @property
+    @abc.abstractmethod
     def parameters(self) -> dict[str, float | str | None]:
         raise NotImplementedError
 

--- a/mfglib/alg/fictitious_play.py
+++ b/mfglib/alg/fictitious_play.py
@@ -89,7 +89,7 @@ class FictitiousPlay(Algorithm[State]):
         return state.next(pi_i)
 
     @property
-    def parameters(self) -> dict[str, float | str]:
+    def parameters(self) -> dict[str, float | str | None]:
         return {"alpha": self.alpha}
 
     @classmethod

--- a/mfglib/alg/fictitious_play.py
+++ b/mfglib/alg/fictitious_play.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
-import dataclasses
-
 import optuna
 import torch
 
-import mfglib.alg.abc
-from mfglib.alg.abc import Algorithm
+from mfglib.alg.abc import Iterative
 from mfglib.alg.greedy_policy_given_mean_field import Greedy_Policy
 from mfglib.env import Environment
 from mfglib.mean_field import mean_field
 
 
-@dataclasses.dataclass
-class State(mfglib.alg.abc.State):
+class State:
     def __init__(self, env: Environment, pi_0: torch.Tensor) -> None:
-        super().__init__(pi_i=pi_0)
         self.env = env
+        self.pi_i = pi_0
         self.i = 0
 
     def next(self, pi_i: torch.Tensor) -> State:
@@ -25,7 +21,7 @@ class State(mfglib.alg.abc.State):
         return self
 
 
-class FictitiousPlay(Algorithm[State]):
+class FictitiousPlay(Iterative[State]):
     """Fictitious Play algorithm.
 
     Notes

--- a/mfglib/alg/fictitious_play.py
+++ b/mfglib/alg/fictitious_play.py
@@ -73,7 +73,7 @@ class FictitiousPlay(Iterative[State]):
         mu = L.flatten(start_dim=1 + states_dim).sum(dim=-1, keepdim=True)
         mu_br = L_br.flatten(start_dim=1 + states_dim).sum(dim=-1, keepdim=True)
 
-        alpha_i = self.alpha if self.alpha else 1 / (state.i + 1)
+        alpha_i = self.alpha if self.alpha else 1 / (state.i + 2)
 
         numer = (1 - alpha_i) * mu * pi + alpha_i * mu_br * pi_br
         denom = (1 - alpha_i) * mu + alpha_i * mu_br

--- a/mfglib/alg/fictitious_play.py
+++ b/mfglib/alg/fictitious_play.py
@@ -11,7 +11,7 @@ from mfglib.env import Environment
 from mfglib.mean_field import mean_field
 
 
-@dataclass(kw_only=True)
+@dataclass
 class State:
     i: int
     env: Environment
@@ -62,7 +62,7 @@ class FictitiousPlay(Iterative[State]):
     def init_state(self, env: Environment, pi_0: torch.Tensor) -> State:
         return State(i=0, env=env, pi=pi_0)
 
-    def step_state(self, state: State) -> State:
+    def step_next_state(self, state: State) -> State:
         L = mean_field(state.env, state.pi)
         pi_br = Greedy_Policy(state.env, L)
         L_br = mean_field(state.env, pi_br)

--- a/mfglib/alg/mf_omo.py
+++ b/mfglib/alg/mf_omo.py
@@ -20,9 +20,6 @@ from mfglib.alg.mf_omo_obj import mf_omo_obj
 from mfglib.alg.mf_omo_residual_balancing import mf_omo_residual_balancing
 from mfglib.alg.utils import (
     _ensure_free_tensor,
-    _print_fancy_header,
-    _print_fancy_table_row,
-    _print_solve_complete,
     _trigger_early_stopping,
     extract_policy_from_mean_field,
     hat_initialization,
@@ -348,7 +345,6 @@ class MFOMO(Algorithm):
         pis = [pi]
         argmin = 0
         expls = [exploitability_score(env, pi)]
-        t_0 = time.time()
         rts = [0.0]
 
         logger = Logger(verbose)

--- a/mfglib/alg/mf_omo.py
+++ b/mfglib/alg/mf_omo.py
@@ -23,7 +23,6 @@ from mfglib.alg.utils import (
     _trigger_early_stopping,
     extract_policy_from_mean_field,
     hat_initialization,
-    tuple_prod,
 )
 from mfglib.env import Environment
 from mfglib.scoring import exploitability_score
@@ -207,14 +206,14 @@ class MFOMO(Algorithm):
 
     def _init_L(self, env_instance: Environment, pi: torch.Tensor) -> torch.Tensor:
         if self._L_or_u is None:
-            return pi / tuple_prod(env_instance.S)
+            return pi / env_instance.n_states
         else:
             return self._L_or_u
 
     def _init_u(self, env_instance: Environment, pi: torch.Tensor) -> torch.Tensor:
         # following pi(a|s)=L(s,a)/mu(s), this mean-field yields policy pi_np
         if self._L_or_u is None:
-            L = pi / tuple_prod(env_instance.S)
+            L = pi / env_instance.n_states
             if (L == 0).any():
                 raise ValueError("zero value encountered; unable to take log")
             return torch.log(L)
@@ -224,8 +223,8 @@ class MFOMO(Algorithm):
     def _init_z(self, env_instance: Environment, L: torch.Tensor) -> torch.Tensor:
         if self._z_or_v is None:
             T = env_instance.T
-            n_s = tuple_prod(env_instance.S)
-            n_a = tuple_prod(env_instance.A)
+            n_s = env_instance.n_states
+            n_a = env_instance.n_actions
             if self.hat_init:
                 z_hat, _ = hat_initialization(env_instance, L, self.parameterize)
                 return z_hat  # type: ignore[return-value]
@@ -236,8 +235,8 @@ class MFOMO(Algorithm):
     def _init_v(self, env_instance: Environment, L: torch.Tensor) -> torch.Tensor:
         if self._z_or_v is None:
             T = env_instance.T
-            n_s = tuple_prod(env_instance.S)
-            n_a = tuple_prod(env_instance.A)
+            n_s = env_instance.n_states
+            n_a = env_instance.n_actions
             if self.hat_init:
                 v_hat, _ = hat_initialization(env_instance, L, self.parameterize)
                 if v_hat is not None:
@@ -249,7 +248,7 @@ class MFOMO(Algorithm):
     def _init_y(self, env_instance: Environment, L: torch.Tensor) -> torch.Tensor:
         if self._y_or_w is None:
             T = env_instance.T
-            n_s = tuple_prod(env_instance.S)
+            n_s = env_instance.n_states
             if self.hat_init:
                 _, y_hat = hat_initialization(env_instance, L, self.parameterize)
                 return y_hat
@@ -260,7 +259,7 @@ class MFOMO(Algorithm):
     def _init_w(self, env_instance: Environment, L: torch.Tensor) -> torch.Tensor:
         if self._y_or_w is None:
             T = env_instance.T
-            n_s = tuple_prod(env_instance.S)
+            n_s = env_instance.n_states
             if self.hat_init:
                 _, w_hat = hat_initialization(env_instance, L, self.parameterize)
                 return w_hat

--- a/mfglib/alg/mf_omo.py
+++ b/mfglib/alg/mf_omo.py
@@ -364,7 +364,7 @@ class MFOMO(Algorithm):
                 "m3": self.m3,
                 "parameterize": self.parameterize,
                 "hat_init": self.hat_init,
-                "optimizer": self.optimizer["name"],
+                "optimizer": self.optimizer,
             },
             atol=atol,
             rtol=rtol,

--- a/mfglib/alg/mf_omo.py
+++ b/mfglib/alg/mf_omo.py
@@ -283,7 +283,8 @@ class MFOMO(Algorithm):
         max_iter: int = DEFAULT_MAX_ITER,
         atol: float | None = DEFAULT_ATOL,
         rtol: float | None = DEFAULT_RTOL,
-        verbose: int = 0,
+        verbose: bool = False,
+        print_every: int = 50,
     ) -> tuple[list[torch.Tensor], list[float], list[float]]:
         """Mean-Field Occupation Measure Optimization algorithm.
 
@@ -302,6 +303,8 @@ class MFOMO(Algorithm):
             Relative tolerance criteria for early stopping.
         verbose
             Print convergence information during iteration.
+        print_every
+            Control how many iterations between printouts.
         """
         T = env.T
         S = env.S
@@ -346,7 +349,7 @@ class MFOMO(Algorithm):
         expls = [exploitability_score(env, pi)]
         rts = [0.0]
 
-        logger = Logger(verbose)
+        logger = Logger(verbose, print_every)
         logger.display_info(
             env=env,
             cls=f"{self.__class__.__name__}",

--- a/mfglib/alg/mf_omo_constraints.py
+++ b/mfglib/alg/mf_omo_constraints.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import torch
 
-from mfglib.alg.utils import project_onto_simplex, tuple_prod
+from mfglib.alg.utils import project_onto_simplex
 from mfglib.env import Environment
 
 
@@ -37,8 +37,8 @@ def mf_omo_constraints(
     r_max = env_instance.r_max  # reward supremum
 
     # Auxiliary variables
-    n_s = tuple_prod(S)
-    n_a = tuple_prod(A)
+    n_s = env_instance.n_states
+    n_a = env_instance.n_actions
 
     # Clone and detach tensors
     L_p = L.clone().detach()

--- a/mfglib/alg/mf_omo_obj.py
+++ b/mfglib/alg/mf_omo_obj.py
@@ -5,7 +5,6 @@ from typing import Literal
 import torch
 
 from mfglib.alg.mf_omo_params import mf_omo_params
-from mfglib.alg.utils import tuple_prod
 from mfglib.env import Environment
 
 
@@ -51,8 +50,8 @@ def mf_omo_obj(
     r_max = env_instance.r_max
 
     # Auxiliary variables
-    n_s = tuple_prod(S)
-    n_a = tuple_prod(A)
+    n_s = env_instance.n_states
+    n_a = env_instance.n_actions
     c_v = n_s * n_a * (T**2 + T + 2) * r_max
     c_w = n_s * (T + 1) * (T + 2) * r_max / 2 / torch.sqrt(torch.tensor(n_s * (T + 1)))
 

--- a/mfglib/alg/mf_omo_params.py
+++ b/mfglib/alg/mf_omo_params.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import torch
 
-from mfglib.alg.utils import tuple_prod
 from mfglib.env import Environment
 
 
@@ -32,8 +31,8 @@ def mf_omo_params(
 
     # Auxiliary variables
     l_s = len(S)
-    n_s = tuple_prod(S)
-    n_a = tuple_prod(A)
+    n_s = env_instance.n_states
+    n_a = env_instance.n_actions
     v = torch.zeros((n_s, n_a))
     v[0, :] = 1.0
     z = v.clone()  # matrix z with a different column arrangement

--- a/mfglib/alg/mf_omo_residual_balancing.py
+++ b/mfglib/alg/mf_omo_residual_balancing.py
@@ -5,7 +5,6 @@ from typing import Literal
 import torch
 
 from mfglib.alg.mf_omo_params import mf_omo_params
-from mfglib.alg.utils import tuple_prod
 from mfglib.env import Environment
 
 
@@ -51,8 +50,8 @@ def mf_omo_residual_balancing(
     r_max = env_instance.r_max
 
     # Auxiliary variables
-    n_s = tuple_prod(S)
-    n_a = tuple_prod(A)
+    n_s = env_instance.n_states
+    n_a = env_instance.n_states
     c_v = n_s * n_a * (T**2 + T + 2) * r_max
     c_w = n_s * (T + 1) * (T + 2) * r_max / 2 / torch.sqrt(torch.tensor(n_s * (T + 1)))
 

--- a/mfglib/alg/mf_omo_residual_balancing.py
+++ b/mfglib/alg/mf_omo_residual_balancing.py
@@ -51,7 +51,7 @@ def mf_omo_residual_balancing(
 
     # Auxiliary variables
     n_s = env_instance.n_states
-    n_a = env_instance.n_states
+    n_a = env_instance.n_actions
     c_v = n_s * n_a * (T**2 + T + 2) * r_max
     c_w = n_s * (T + 1) * (T + 2) * r_max / 2 / torch.sqrt(torch.tensor(n_s * (T + 1)))
 

--- a/mfglib/alg/occupation_measure_inclusion.py
+++ b/mfglib/alg/occupation_measure_inclusion.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import time
-from typing import Literal
+from dataclasses import dataclass
 
 import numpy as np
 import optuna
@@ -9,19 +8,11 @@ import osqp
 import torch
 from scipy import sparse
 
-from mfglib.alg.abc import DEFAULT_ATOL, DEFAULT_MAX_ITER, DEFAULT_RTOL, Algorithm
+from mfglib.alg.abc import Iterative
 from mfglib.alg.mf_omo_params import mf_omo_params
-from mfglib.alg.utils import (
-    _ensure_free_tensor,
-    _print_fancy_header,
-    _print_fancy_table_row,
-    _print_solve_complete,
-    _trigger_early_stopping,
-    extract_policy_from_mean_field,
-)
+from mfglib.alg.utils import extract_policy_from_mean_field
 from mfglib.env import Environment
 from mfglib.mean_field import mean_field
-from mfglib.scoring import exploitability_score
 
 
 # TODO: Change to support warm start and update vectors to be more efficient
@@ -55,7 +46,14 @@ def osqp_proj(d: torch.Tensor, b: torch.Tensor, A: torch.Tensor) -> torch.Tensor
     return sol
 
 
-class OccupationMeasureInclusion(Algorithm):
+@dataclass(kw_only=True)
+class State:
+    env: Environment
+    pi: torch.Tensor
+    d: torch.Tensor
+
+
+class OccupationMeasureInclusion(Iterative[State]):
     """Mean-Field Occupation Measure Inclusion with Forward-Backward Splitting.
 
     Notes
@@ -84,102 +82,22 @@ class OccupationMeasureInclusion(Algorithm):
         """Represent algorithm instance and associated parameters with a string."""
         return f"OccupationMeasureInclusion({self.alpha=}, {self.eta=})"
 
-    def solve(
-        self,
-        env: Environment,
-        *,
-        pi_0: Literal["uniform"] | torch.Tensor = "uniform",
-        max_iter: int = DEFAULT_MAX_ITER,
-        atol: float | None = DEFAULT_ATOL,
-        rtol: float | None = DEFAULT_RTOL,
-        verbose: int = 0,
-    ) -> tuple[list[torch.Tensor], list[float], list[float]]:
-        """Run the algorithm and solve for a Nash-Equilibrium policy.
+    def init_state(self, env: Environment, pi_0: torch.Tensor) -> State:
+        d = mean_field(env, pi_0)
+        return State(env=env, pi=pi_0, d=d)
 
-        Args
-        ----
-        env
-            An instance of a specific environment.
-        pi_0
-            A numpy array of size (T+1,)+S+A representing the initial policy.
-            If 'uniform', the initial policy will be the uniform distribution.
-        max_iter
-            Maximum number of iterations to run.
-        atol
-            Absolute tolerance criteria for early stopping.
-        rtol
-            Relative tolerance criteria for early stopping.
-        verbose
-            Print convergence information during iteration.
-        """
-        pi = _ensure_free_tensor(pi_0, env)
+    def step_state(self, state: State) -> State:
+        d = state.d
+        d_shape = list(d.shape)
+        b, A_d, c_d = mf_omo_params(state.env, d)
+        d -= self.alpha * (c_d.reshape(*d_shape) + self.eta * d)
+        d = osqp_proj(d.flatten(), b, A_d).reshape(*d_shape)
+        pi = extract_policy_from_mean_field(state.env, d.clone().detach())
+        return State(env=state.env, pi=pi, d=d)
 
-        solutions = [pi]
-        argmin = 0
-        scores = [exploitability_score(env, pi)]
-        runtimes = [0.0]
-
-        if verbose:
-            _print_fancy_header(
-                alg_instance=self,
-                env_instance=env,
-                max_iter=max_iter,
-                atol=atol,
-                rtol=rtol,
-            )
-            _print_fancy_table_row(
-                n=0,
-                score_n=scores[0],
-                score_0=scores[0],
-                argmin=argmin,
-                runtime_n=runtimes[0],
-            )
-
-        if _trigger_early_stopping(scores[0], scores[0], atol, rtol):
-            if verbose:
-                _print_solve_complete(seconds_elapsed=runtimes[0])
-            return solutions, scores, runtimes
-
-        # initialize d = L^pi
-        d = mean_field(env, pi)
-        d_shape = list(d.shape)  # non-flattened shape of d
-
-        t = time.time()
-        for n in range(1, max_iter + 1):
-            # obtain occupation-measure params
-            b, A_d, c_d = mf_omo_params(env, d)
-
-            # Update d and pi
-            d -= self.alpha * (c_d.reshape(*d_shape) + self.eta * d)
-            d = osqp_proj(d.flatten(), b, A_d).reshape(*d_shape)
-            pi = extract_policy_from_mean_field(env, d.clone().detach())
-
-            solutions.append(
-                pi.clone().detach()
-            )  # do we need to clone + detach again? no? same for MF-OMO？
-            scores.append(exploitability_score(env, pi))
-            if scores[n] < scores[argmin]:
-                argmin = n
-            runtimes.append(time.time() - t)
-
-            if verbose:
-                _print_fancy_table_row(
-                    n=n,
-                    score_n=scores[n],
-                    score_0=scores[0],
-                    argmin=argmin,
-                    runtime_n=runtimes[n],
-                )
-
-            if _trigger_early_stopping(scores[0], scores[n], atol, rtol):
-                if verbose:
-                    _print_solve_complete(seconds_elapsed=runtimes[n])
-                return solutions, scores, runtimes
-
-        if verbose:
-            _print_solve_complete(seconds_elapsed=time.time() - t)
-
-        return solutions, scores, runtimes
+    @property
+    def parameters(self) -> dict[str, float | str | None]:
+        return {"alpha": self.alpha, "eta": self.eta}
 
     @classmethod
     def _init_tuner_instance(cls, trial: optuna.Trial) -> OccupationMeasureInclusion:

--- a/mfglib/alg/occupation_measure_inclusion.py
+++ b/mfglib/alg/occupation_measure_inclusion.py
@@ -46,7 +46,7 @@ def osqp_proj(d: torch.Tensor, b: torch.Tensor, A: torch.Tensor) -> torch.Tensor
     return sol
 
 
-@dataclass(kw_only=True)
+@dataclass
 class State:
     env: Environment
     pi: torch.Tensor
@@ -86,7 +86,7 @@ class OccupationMeasureInclusion(Iterative[State]):
         d = mean_field(env, pi_0)
         return State(env=env, pi=pi_0, d=d)
 
-    def step_state(self, state: State) -> State:
+    def step_next_state(self, state: State) -> State:
         d = state.d
         d_shape = list(d.shape)
         b, A_d, c_d = mf_omo_params(state.env, d)

--- a/mfglib/alg/online_mirror_descent.py
+++ b/mfglib/alg/online_mirror_descent.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
-import dataclasses
-
 import optuna
 import torch
 
-import mfglib
-from mfglib.alg.abc import Algorithm
+from mfglib.alg.abc import Iterative
 from mfglib.alg.q_fn import QFn
 from mfglib.env import Environment
 from mfglib.mean_field import mean_field
 
 
-@dataclasses.dataclass
-class State(mfglib.alg.abc.State):
+class State:
     def __init__(self, env: Environment, pi_0: torch.Tensor) -> None:
-        super().__init__(pi_i=pi_0)
         self.env = env
+        self.pi_i = pi_0
         self.y = torch.zeros(env.T + 1, *env.S, *env.A)
 
     def next(self, pi_i: torch.Tensor) -> State:
@@ -24,7 +20,7 @@ class State(mfglib.alg.abc.State):
         return self
 
 
-class OnlineMirrorDescent(Algorithm[State]):
+class OnlineMirrorDescent(Iterative[State]):
     """Online Mirror Descent algorithm.
 
     Notes

--- a/mfglib/alg/online_mirror_descent.py
+++ b/mfglib/alg/online_mirror_descent.py
@@ -50,8 +50,8 @@ class OnlineMirrorDescent(Iterative[State]):
         L = mean_field(state.env, state.pi)
         Q = QFn(state.env, L, verify_integrity=False).for_policy(state.pi)
         y = state.y + self.alpha * Q
-        states_dim = len(state.env.S)
-        y_flat = state.y.flatten(start_dim=1 + states_dim)
+        n_state_coords = len(state.env.S)
+        y_flat = y.flatten(start_dim=1 + n_state_coords)
         softmax = torch.nn.Softmax(dim=-1)
         pi = softmax(y_flat).reshape(state.env.T + 1, *state.env.S, *state.env.A)
         return State(env=state.env, pi=pi, y=y)

--- a/mfglib/alg/online_mirror_descent.py
+++ b/mfglib/alg/online_mirror_descent.py
@@ -11,7 +11,7 @@ from mfglib.env import Environment
 from mfglib.mean_field import mean_field
 
 
-@dataclass(kw_only=True)
+@dataclass
 class State:
     env: Environment
     pi: torch.Tensor
@@ -46,7 +46,7 @@ class OnlineMirrorDescent(Iterative[State]):
     def init_state(self, env: Environment, pi_0: torch.Tensor) -> State:
         return State(env=env, pi=pi_0, y=torch.zeros(env.T + 1, *env.S, *env.A))
 
-    def step_state(self, state: State) -> State:
+    def step_next_state(self, state: State) -> State:
         L = mean_field(state.env, state.pi)
         Q = QFn(state.env, L, verify_integrity=False).for_policy(state.pi)
         y = state.y + self.alpha * Q

--- a/mfglib/alg/online_mirror_descent.py
+++ b/mfglib/alg/online_mirror_descent.py
@@ -1,26 +1,30 @@
 from __future__ import annotations
 
-import time
-from typing import Literal, cast
+import dataclasses
 
 import optuna
 import torch
 
-from mfglib.alg.abc import DEFAULT_ATOL, DEFAULT_MAX_ITER, DEFAULT_RTOL, Algorithm
+import mfglib
+from mfglib.alg.abc import Algorithm
 from mfglib.alg.q_fn import QFn
-from mfglib.alg.utils import (
-    _ensure_free_tensor,
-    _print_fancy_header,
-    _print_fancy_table_row,
-    _print_solve_complete,
-    _trigger_early_stopping,
-)
 from mfglib.env import Environment
 from mfglib.mean_field import mean_field
-from mfglib.scoring import exploitability_score
 
 
-class OnlineMirrorDescent(Algorithm):
+@dataclasses.dataclass
+class State(mfglib.alg.abc.State):
+    def __init__(self, env: Environment, pi_0: torch.Tensor) -> None:
+        super().__init__(pi_i=pi_0)
+        self.env = env
+        self.y = torch.zeros(env.T + 1, *env.S, *env.A)
+
+    def next(self, pi_i: torch.Tensor) -> State:
+        self.pi_i = pi_i
+        return self
+
+
+class OnlineMirrorDescent(Algorithm[State]):
     """Online Mirror Descent algorithm.
 
     Notes
@@ -45,113 +49,22 @@ class OnlineMirrorDescent(Algorithm):
         """Represent algorithm instance and associated parameters with a string."""
         return f"OnlineMirrorDescent(alpha={self.alpha})"
 
-    def solve(
-        self,
-        env_instance: Environment,
-        *,
-        pi: Literal["uniform"] | torch.Tensor = "uniform",
-        max_iter: int = DEFAULT_MAX_ITER,
-        atol: float | None = DEFAULT_ATOL,
-        rtol: float | None = DEFAULT_RTOL,
-        verbose: bool = False,
-    ) -> tuple[list[torch.Tensor], list[float], list[float]]:
-        """Run the algorithm and solve for a Nash-Equilibrium policy.
+    def init_state(self, env: Environment, pi_0: torch.Tensor) -> State:
+        return State(env=env, pi_0=pi_0)
 
-        Args
-        ----
-        env_instance
-            An instance of a specific environment.
-        pi
-            A numpy array of size (T+1,)+S+A representing the initial policy.
-            If 'uniform', the initial policy will be the uniform distribution.
-        max_iter
-            Maximum number of iterations to run.
-        atol
-            Absolute tolerance criteria for early stopping.
-        rtol
-            Relative tolerance criteria for early stopping.
-        verbose
-            Print convergence information during iteration.
-        """
-        T = env_instance.T
-        S = env_instance.S
-        A = env_instance.A
+    def step_state(self, state: State) -> State:
+        L = mean_field(state.env, state.pi_i)
+        Q = QFn(state.env, L, verify_integrity=False).for_policy(state.pi_i)
+        state.y += self.alpha * Q
+        states_dim = len(state.env.S)
+        y_flat = state.y.flatten(start_dim=1 + states_dim)
+        softmax = torch.nn.Softmax(dim=-1)
+        pi_i = softmax(y_flat).reshape(state.env.T + 1, *state.env.S, *state.env.A)
+        return state.next(pi_i)
 
-        y = torch.zeros((T + 1,) + S + A)
-
-        # Auxiliary functions
-        soft_max = torch.nn.Softmax(dim=-1)
-
-        # Auxiliary variables
-        l_s = len(S)
-
-        pi = _ensure_free_tensor(pi, env_instance)
-
-        solutions = [pi]
-        argmin = 0
-        scores = [exploitability_score(env_instance, pi)]
-        runtimes = [0.0]
-
-        if verbose:
-            _print_fancy_header(
-                alg_instance=self,
-                env_instance=env_instance,
-                max_iter=max_iter,
-                atol=atol,
-                rtol=rtol,
-            )
-            _print_fancy_table_row(
-                n=0,
-                score_n=scores[0],
-                score_0=scores[0],
-                argmin=argmin,
-                runtime_n=runtimes[0],
-            )
-
-        if _trigger_early_stopping(scores[0], scores[0], atol, rtol):
-            if verbose:
-                _print_solve_complete(seconds_elapsed=runtimes[0])
-            return solutions, scores, runtimes
-
-        t = time.time()
-        for n in range(1, max_iter + 1):
-            # Mean-field corresponding to the policy
-            L = mean_field(env_instance, pi)
-
-            # Q-function corresponding to the policy and mean-field
-            Q = QFn(env_instance, L, verify_integrity=False).for_policy(pi)
-
-            # Update y and pi
-            y += self.alpha * Q
-            pi = cast(
-                torch.Tensor,
-                soft_max(y.flatten(start_dim=1 + l_s)).reshape((T + 1,) + S + A),
-            )
-
-            solutions.append(pi.clone().detach())
-            scores.append(exploitability_score(env_instance, pi))
-            if scores[n] < scores[argmin]:
-                argmin = n
-            runtimes.append(time.time() - t)
-
-            if verbose:
-                _print_fancy_table_row(
-                    n=n,
-                    score_n=scores[n],
-                    score_0=scores[0],
-                    argmin=argmin,
-                    runtime_n=runtimes[n],
-                )
-
-            if _trigger_early_stopping(scores[0], scores[n], atol, rtol):
-                if verbose:
-                    _print_solve_complete(seconds_elapsed=runtimes[n])
-                return solutions, scores, runtimes
-
-        if verbose:
-            _print_solve_complete(seconds_elapsed=time.time() - t)
-
-        return solutions, scores, runtimes
+    @property
+    def parameters(self) -> dict[str, float | str]:
+        return {"alpha": self.alpha}
 
     @classmethod
     def _init_tuner_instance(cls, trial: optuna.Trial) -> OnlineMirrorDescent:

--- a/mfglib/alg/online_mirror_descent.py
+++ b/mfglib/alg/online_mirror_descent.py
@@ -63,7 +63,7 @@ class OnlineMirrorDescent(Algorithm[State]):
         return state.next(pi_i)
 
     @property
-    def parameters(self) -> dict[str, float | str]:
+    def parameters(self) -> dict[str, float | str | None]:
         return {"alpha": self.alpha}
 
     @classmethod

--- a/mfglib/alg/q_fn.py
+++ b/mfglib/alg/q_fn.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import torch
 
-from mfglib.env import Environment
+if TYPE_CHECKING:
+    from mfglib.env import Environment
 
 
 class QFn:

--- a/mfglib/alg/utils.py
+++ b/mfglib/alg/utils.py
@@ -2,16 +2,12 @@ from __future__ import annotations
 
 import warnings
 from functools import reduce
-from typing import TYPE_CHECKING, Literal, TypeVar
+from typing import Literal, TypeVar
 
 import torch
 
-from mfglib import __version__
 from mfglib.alg.q_fn import QFn
 from mfglib.env import Environment
-
-if TYPE_CHECKING:
-    from mfglib.alg.abc import Algorithm
 
 T = TypeVar("T", int, float)
 
@@ -19,55 +15,6 @@ T = TypeVar("T", int, float)
 def tuple_prod(tup: tuple[T, ...]) -> T:
     """Compute product of the elements in a tuple."""
     return reduce(lambda x, y: x * y, tup)
-
-
-HEADER = "| iter |  expl_n  | expl_n / expl_0 | argmin_{0..n} expl_i | time (s) |"
-
-
-def _print_fancy_header(
-    *,
-    alg_instance: Algorithm,
-    env_instance: Environment,
-    max_iter: int,
-    atol: float | None,
-    rtol: float | None,
-) -> None:
-    title = f"MFGLib v{__version__} : A Library for Mean-Field Games"
-    print("=" * len(HEADER))
-    print(f"{title:^{len(HEADER)}}")
-    print(f"{'(c) RADAR Research Lab, UC Berkeley':^{len(HEADER)}}")
-    print("=" * len(HEADER))
-    print()
-    print("Environment summary:")
-    print(f"\tS={env_instance.S}")
-    print(f"\tA{env_instance.A}")
-    print(f"\tT={env_instance.T}")
-    print(f"\tr_max={env_instance.r_max}")
-    print()
-    print("Algorithm summary:")
-    print(f"\t{alg_instance}")
-    print(f"\t{atol=}")
-    print(f"\t{rtol=}")
-    print(f"\t{max_iter=}")
-    print()
-    print("-" * len(HEADER))
-    print(HEADER)
-    print("-" * len(HEADER))
-
-
-def _print_fancy_table_row(
-    *, n: int, score_n: float, score_0: float, argmin: int, runtime_n: float
-) -> None:
-    print(
-        f"|{n:^6}|{score_n:^10.5f}|{score_n / score_0:^17.5f}"
-        f"|{argmin:^22}|{runtime_n:^10.3f}|"
-    )
-
-
-def _print_solve_complete(*, seconds_elapsed: float) -> None:
-    print("-" * len(HEADER))
-    print()
-    print(f"Solve complete ({seconds_elapsed:.3f} seconds)")
 
 
 def _ensure_free_tensor(

--- a/mfglib/alg/utils.py
+++ b/mfglib/alg/utils.py
@@ -92,7 +92,6 @@ def _trigger_early_stopping(
     if atol or rtol:
         atolv = 0.0 if atol is None else atol
         rtolv = 0.0 if rtol is None else rtol
-
         return score_n <= atolv + rtolv * score_0
     else:
         return False

--- a/mfglib/alg/utils.py
+++ b/mfglib/alg/utils.py
@@ -1,22 +1,15 @@
 from __future__ import annotations
 
 import warnings
-from functools import reduce
-from typing import TYPE_CHECKING, Literal, TypeVar
+from typing import TYPE_CHECKING, Literal
 
+import numpy as np
 import torch
 
 from mfglib.alg.q_fn import QFn
 
 if TYPE_CHECKING:
     from mfglib.env import Environment
-
-T = TypeVar("T", int, float)
-
-
-def tuple_prod(tup: tuple[T, ...]) -> T:
-    """Compute product of the elements in a tuple."""
-    return reduce(lambda x, y: x * y, tup)
 
 
 def _ensure_free_tensor(
@@ -100,7 +93,7 @@ def extract_policy_from_mean_field(
     # Auxiliary variables
     l_s = len(S)
     l_a = len(A)
-    n_a = tuple_prod(A)
+    n_a = np.prod(A).item()
     ones_ts = (1,) * (l_s + 1)
     ats_to_tsa = tuple(range(l_a, l_a + 1 + l_s)) + tuple(range(l_a))
 
@@ -130,8 +123,8 @@ def hat_initialization(
     r_max = env_instance.r_max
 
     # Auxiliary parameters
-    n_s = tuple_prod(S)
-    n_a = tuple_prod(A)
+    n_s = np.prod(S).item()
+    n_a = np.prod(A).item()
     l_a, l_s = len(A), len(S)
     ones_s = (1,) * l_s
     as_to_sa = tuple(range(l_a, l_a + l_s)) + tuple(range(l_a))

--- a/mfglib/alg/utils.py
+++ b/mfglib/alg/utils.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import warnings
 from functools import reduce
-from typing import Literal, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 import torch
 
 from mfglib.alg.q_fn import QFn
-from mfglib.env import Environment
+
+if TYPE_CHECKING:
+    from mfglib.env import Environment
 
 T = TypeVar("T", int, float)
 

--- a/mfglib/env/environment.py
+++ b/mfglib/env/environment.py
@@ -76,6 +76,10 @@ class Environment:
     def n_actions(self) -> int:
         return torch.tensor(self.A).prod().item()
 
+    @property
+    def n_states(self) -> int:
+        return torch.tensor(self.S).prod().item()
+
     @classmethod
     def beach_bar(
         cls,

--- a/mfglib/env/environment.py
+++ b/mfglib/env/environment.py
@@ -5,6 +5,8 @@ from typing import Literal, Protocol
 
 import torch
 
+from mfglib.alg.utils import tuple_prod
+
 
 # By defining Protocols here, we allow a user to pass any object that implements
 # `__call__`. In particular, this allows a user to pass either a function or a class
@@ -74,11 +76,11 @@ class Environment:
 
     @property
     def n_actions(self) -> int:
-        return torch.tensor(self.A).prod().item()
+        return tuple_prod(self.A)
 
     @property
     def n_states(self) -> int:
-        return torch.tensor(self.S).prod().item()
+        return tuple_prod(self.S)
 
     @classmethod
     def beach_bar(

--- a/mfglib/env/environment.py
+++ b/mfglib/env/environment.py
@@ -72,6 +72,10 @@ class Environment:
     def prob(self, t: int, L_t: torch.Tensor) -> torch.Tensor:
         return self.transition_fn(self, t, L_t)
 
+    @property
+    def n_actions(self) -> int:
+        return torch.tensor(self.A).prod().item()
+
     @classmethod
     def beach_bar(
         cls,

--- a/mfglib/env/environment.py
+++ b/mfglib/env/environment.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import math
 from typing import Literal, Protocol
 
+import numpy as np
 import torch
-
-from mfglib.alg.utils import tuple_prod
 
 
 # By defining Protocols here, we allow a user to pass any object that implements
@@ -76,11 +75,11 @@ class Environment:
 
     @property
     def n_actions(self) -> int:
-        return tuple_prod(self.A)
+        return np.prod(self.A).item()
 
     @property
     def n_states(self) -> int:
-        return tuple_prod(self.S)
+        return np.prod(self.S).item()
 
     @classmethod
     def beach_bar(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ numpy = "^2"
 optuna = "^3.0"
 osqp = "^0"
 scipy = "^1"
+rich = "^14.0.0"
 
 [tool.poetry.group.dev.dependencies]
 isort = "6.0.0"

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -105,7 +105,7 @@ def test_tuner_on_rps(alg: Algorithm, stat: Literal["iter", "rt", "expl"]) -> No
 
     alg.tune(
         envs=[rps],
-        pi0s="uniform",
+        pi_0s="uniform",
         metric=FailureRate(fail_thresh=100, stat=stat),
         solve_kwargs={"max_iter": 200},
         n_trials=5,
@@ -115,7 +115,7 @@ def test_tuner_on_rps(alg: Algorithm, stat: Literal["iter", "rt", "expl"]) -> No
     if stat != "rt":
         alg.tune(
             envs=[rps],
-            pi0s="uniform",
+            pi_0s="uniform",
             metric=FailureRate(stat=stat),
             solve_kwargs={"max_iter": 200},
             n_trials=5,
@@ -123,7 +123,7 @@ def test_tuner_on_rps(alg: Algorithm, stat: Literal["iter", "rt", "expl"]) -> No
         )
     alg.tune(
         envs=[rps],
-        pi0s="uniform",
+        pi_0s="uniform",
         metric=GeometricMean(shift=1.0, stat=stat),
         solve_kwargs={"max_iter": 200},
         n_trials=5,

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,8 +1,8 @@
+import numpy as np
 import pytest
 import torch
 
 from mfglib.alg import OnlineMirrorDescent
-from mfglib.alg.utils import tuple_prod
 from mfglib.env import Environment
 
 
@@ -19,7 +19,7 @@ def test_beach_bar(T: int, n: int, p_still: float) -> None:
     l_s = 1
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -57,7 +57,7 @@ def test_building_evacuation(T: int, n_floor: int, floor_l: int, floor_w: int) -
     l_s = 3
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -91,7 +91,7 @@ def test_conservative_treasure_hunting(T: int, n: int) -> None:
     l_s = 1
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -129,7 +129,7 @@ def test_crowd_motion(T: int, torus_l: int, torus_w: int, p_still: float) -> Non
     l_s = 2
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -166,7 +166,7 @@ def test_equilibrium_price(T: int, s_inv: int, Q: int, H: int, sigma: float) -> 
     l_s = 1
     l_a = 2
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -198,7 +198,7 @@ def test_left_right() -> None:
     l_s = 1
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -230,7 +230,7 @@ def test_linear_quadratic() -> None:
     l_s = 1
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -265,7 +265,7 @@ def test_random_linear(T: int, n: int, m: float) -> None:
     l_s = 1
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -298,7 +298,7 @@ def test_rock_paper_scissors(T: int) -> None:
     l_s = 1
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa
@@ -331,7 +331,7 @@ def test_susceptible_infected(T: int) -> None:
     l_s = 1
     l_a = 1
 
-    L = torch.ones(size=size_tsa) / tuple_prod(size_sa)
+    L = torch.ones(size=size_tsa) / np.prod(size_sa).item()
     r = env.reward(0, L[0])
     p = env.prob(0, L[0])
     assert r.shape == size_sa

--- a/tests/test_q_function.py
+++ b/tests/test_q_function.py
@@ -3,7 +3,6 @@ import torch
 from torch.testing import assert_close
 
 from mfglib.alg.q_fn import QFn
-from mfglib.alg.utils import tuple_prod
 from mfglib.env import Environment
 
 
@@ -21,8 +20,8 @@ def test_q_function(env: Environment) -> None:
     """Primarily a property-based test."""
     size = (env.T + 1, *env.S, *env.A)
 
-    L = torch.ones(size=size) / tuple_prod(env.S + env.A)
-    pi = torch.ones(size=size) / tuple_prod(env.A)
+    L = torch.ones(size=size) / env.n_states / env.n_actions
+    pi = torch.ones(size=size) / env.n_actions
 
     optimal = QFn(env, L).optimal()
     assert optimal.size() == torch.Size(size)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,19 +1,11 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
 import torch
 
-from mfglib.alg.utils import hat_initialization, project_onto_simplex, tuple_prod
+from mfglib.alg.utils import hat_initialization, project_onto_simplex
 from mfglib.env import Environment
-
-
-@pytest.mark.parametrize("num_type", [int, float])
-def test_tuple_prod(num_type: type[int] | type[float]) -> None:
-    """Check that the result is correct, and the datatype is preserved."""
-    tup = tuple(num_type(x) for x in range(1, 4))
-    result = tuple_prod(tup)
-    assert result == num_type(6)
-    assert isinstance(result, num_type)
 
 
 def test_project_onto_simplex() -> None:
@@ -44,7 +36,10 @@ def test_project_onto_simplex() -> None:
 def test_hat_initialization(env: Environment) -> None:
     size = (env.T + 1, *env.S, *env.A)
 
-    L = torch.ones(size=size) / tuple_prod(env.S + env.A)
+    def tuple_prod(tup: tuple[int, ...]) -> int:
+        return np.prod(tup).item()
+
+    L = torch.ones(size=size) / np.prod(env.S + env.A).item()
 
     z_hat, y_hat = hat_initialization(env, L, parameterize=False)
     assert isinstance(z_hat, torch.Tensor)


### PR DESCRIPTION
In #50 I designed a `Printer` class that managed verbose printouts during an algorithm's execution. I realized I was able to remove a lot of duplicated code if this `Printer` class also kept track of certain algorithm state variables, such as the index of the best solution among others.

Ultimately the `Printer` class became responsible for two things: 1. managing verbose printouts and 2. tracking certain aspects of the algorithm state. A class with two different purposes is bad design, and suggests it should be split into two different classes, each with a singular purpose. This PR does that.

Instead of a `Printer` class, this PR introduces a `Logger` class that solely handles printing at different verbosity levels.

To remove the duplicated code among the different algorithms, I now have them subclass from a generic `Iterative` class which is itself a subclass of `Algorithm`. An `Iterative` algorithm is any algorithm that proceeds in an iterative fashion to produce policy iterates (all our algorithms behave this way). 

Each subclass of `Iterative` need only to define how to move from one iterate to the next, while the superclass handles logging and the main iteration loop.

This does not change the experience from the user-end. To create a custom algorithm, you still subclass `Algorithm`. 

All the algorithms except `MFOMO` have been reimplemented as subclasses of `Iterative`. `MFOMO` can be ported as well, but will require a little cleanup. 

I will share some numerics to show the new implementations don't differ from the old implementations. But in the meantime, the PR is available for review.